### PR TITLE
Fix HTML not JSON in header, better error handling

### DIFF
--- a/wordpress_json/__init__.py
+++ b/wordpress_json/__init__.py
@@ -16,7 +16,7 @@ Wordpress JSON API (WP-API).
 import requests
 import six
 
-__version__ = '0.2.4',
+__version__ = '0.2.5',
 __author__ = 'Raul Taranu, Dimitar Roustchev'
 
 methods = {

--- a/wordpress_json/__init__.py
+++ b/wordpress_json/__init__.py
@@ -297,9 +297,14 @@ class WordpressJsonWrapper(object):
         elif 'application/json' in http_response.headers.get('Content-Type'):
             return http_response.json()
         else:
-            raise WordpressError(" ".join([
-                "Expected JSON response but got",
-                http_response.headers.get('Content-Type')]))
+            # If not JSON specified in 'Content-Type' it still may be JSON in response BODY so we try to decode it
+            # and we check for errors and keep custom WordPress error in 'except' statement.
+            try:
+                return http_response.json()
+            except:
+                raise WordpressError(" ".join([
+                    "Expected JSON response but got",
+                    http_response.headers.get('Content-Type')]))
 
 
 if __name__ == '__main__':

--- a/wordpress_json/__init__.py
+++ b/wordpress_json/__init__.py
@@ -282,7 +282,8 @@ class WordpressJsonWrapper(object):
         )
 
         if http_response.status_code not in [200, 201]:
-            if 'application/json' in http_response.headers.get('Content-Type'):
+            if 'application/json' in http_response.headers.get('Content-Type') and \
+                    int(http_response.headers.get('Content-Length')) > 0:
                 code = http_response.json().get('code')
                 message = http_response.json().get('message')
             else:


### PR DESCRIPTION
WWP-759, WWP-762

- Parfois, WordPress met un header "Content-Type: text/html" alors qu'en fait, c'est du JSON... La modification du code tente de quand même décoder du JSON même si le "Content-Type" n'est pas "application/json". Le contrôle d'erreur a été laissé et l'erreur est toujours propagée si le contenu renvoyé est incorrect.
- Si on a un code de retour autre que 200 ou 201 et que c'est soi-disant du contenu JSON, on essaie de décoder celui-ci afin de renvoyer les infos. Cependant, si le contenu est vide, ça va générer une erreur de décodage JSON qui nous fera perdre de vue la "vraie" erreur et le vrai statut de celle-ci. Le décodage du JSON est maintenant fait uniquement si le "Content-Length" est plus grand que 0.

Une fois que la PR aura été mergée, il faudra mettre à jour le package en forçant, avec la commande: 
`pip install -I git+https://github.com/epfl-idevelop/python-wordpress-json.git`